### PR TITLE
fix: update REPLAY_RESISTANT_MESSAGE_TYPEHASH to use correct message format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ clean  :; forge clean
 # Remove modules
 remove :; rm -rf .gitmodules && rm -rf .git/modules/* && rm -rf lib && touch .gitmodules && git add . && git commit -m "modules"
 
-install :; forge install foundry-rs/forge-std --no-commit && forge install openzeppelin/openzeppelin-contracts --no-commit 
+install :; forge install foundry-rs/forge-std  && forge install openzeppelin/openzeppelin-contracts
 
 # Update Dependencies
 update:; forge update

--- a/src/SignatureVerifier.sol
+++ b/src/SignatureVerifier.sol
@@ -279,7 +279,7 @@ contract SignatureVerifier {
     }
 
     bytes32 public constant REPLAY_RESISTANT_MESSAGE_TYPEHASH =
-        keccak256("Message(uint256 number,uint256 deadline,uint256 nonce)");
+        keccak256("ReplayResistantMessage(uint256 number,uint256 deadline,uint256 nonce)");
 
     // Now, we also need to keep track of nonces!
     mapping(address => mapping(uint256 => bool)) public noncesUsed;

--- a/src/SignatureVerifier.sol
+++ b/src/SignatureVerifier.sol
@@ -232,7 +232,7 @@ contract SignatureVerifier {
         bytes32 hashStructOfDomainSeparator = i_domain_separator;
 
         // now, we can hash our message struct
-        bytes32 hashedMessage = keccak256(abi.encode(MESSAGE_TYPEHASH, Message({ number: message })));
+        bytes32 hashedMessage = keccak256(abi.encode(MESSAGE_TYPEHASH, message));
 
         // And finally, combine them all
         bytes32 digest = keccak256(abi.encodePacked(prefix, eip712Version, hashStructOfDomainSeparator, hashedMessage));
@@ -307,12 +307,7 @@ contract SignatureVerifier {
         bytes1 eip712Version = bytes1(0x01); // EIP-712 is version 1 of EIP-191
         bytes32 hashStructOfDomainSeparator = i_domain_separator;
 
-        bytes32 hashedMessage = keccak256(
-            abi.encode(
-                REPLAY_RESISTANT_MESSAGE_TYPEHASH,
-                ReplayResistantMessage({ number: message, deadline: deadline, nonce: nonce })
-            )
-        );
+        bytes32 hashedMessage = keccak256(abi.encode(REPLAY_RESISTANT_MESSAGE_TYPEHASH, message, deadline, nonce));
 
         bytes32 digest = keccak256(abi.encodePacked(prefix, eip712Version, hashStructOfDomainSeparator, hashedMessage));
         return ecrecover(digest, _v, _r, _s);


### PR DESCRIPTION
If we take a look at lines 275-282, there's a `ReplayResistantMessage` struct present in `SignatureVerifier.sol`, and below is its typehash.

<img width="1225" height="249" alt="image_2025-07-11_224910676" src="https://github.com/user-attachments/assets/1a2530e3-eb21-4e34-b986-91a424991f91" />

However, as you can notice, the typehash should be kept as `keccak256("ReplayResistantMessage(uint256 number,uint256 deadline,uint256 nonce)");` by following the EIP-712 principles.
