### PR TITLE
Fix EIP712 encoding for string message type

### DIFF
--- a/src/SignatureVerifierWithOZ.sol
+++ b/src/SignatureVerifierWithOZ.sol
@@ -11,7 +11,7 @@ contract SignatureVerifierWithOZ is EIP712 {
     }
 
     bytes32 public constant MESSAGE_TYPEHASH = keccak256(
-        "Message(uint256 message)"
+        "Message(string message)"
     );
 
     constructor(string memory name, string memory version) EIP712(name, version) {}
@@ -20,12 +20,7 @@ contract SignatureVerifierWithOZ is EIP712 {
     function getMessageHash(string calldata _message) public view returns (bytes32) {
         return
             _hashTypedDataV4(
-                keccak256(
-                    abi.encode(
-                        MESSAGE_TYPEHASH,
-                        Message({message: _message})
-                    )
-                )
+                keccak256(abi.encode(MESSAGE_TYPEHASH, keccak256(bytes(_message))))
             );
     }
 


### PR DESCRIPTION
Upon taking a look at the changes you made in the previous PR (i.e. #3), I checked out `SignatureVerifierWithOZ.sol` and made the following changes:

<img width="1109" height="543" alt="image_2025-07-12_111025745" src="https://github.com/user-attachments/assets/8938e75f-a230-4524-bf4d-546aca354a7b" />

Change on line 14 is pretty understandable, and for line 23, [this](https://docs.openzeppelin.com/community-contracts/0.0.1/utilities#cryptography) proves to be useful.

##

Moreover, I came across this blog written by Ciara, titled: [EIP-712 and EIP-191 | Understanding Ethereum Signature Standards](https://www.cyfrin.io/blog/understanding-ethereum-signature-standards-eip-191-eip-712). If possible, then the changes made in the previous PR should be reflected accordingly.
